### PR TITLE
Birria progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,12 +90,12 @@
           <li class="menu-item">
             <div class="menu-item-name">BIRRIA TACO's<span class="menu-item-price">149:-</span></div>
             <div class="menu-item-description">Långkokt högrev, mozzarella, lök, persilja, lime & consumé</div>
-            <div class="progress-bar-container">
-              <div class="menu-item-description">~<span id="amountLeft">100%</span> av grytan finns kvar!</div>
+            <div class="progress-bar-container _100">
+              <div class="menu-item-description">~<span id="amountLeft"/>% kvar!</div>
               <div class="progress-bar">
                   <div class="progress"></div>
               </div>
-              <p class="message"></p>
+              <p class="empty-message">Slut för denna veckan! Åter på onsdag</p>
             </div>
           </li>
            <li class="menu-item">

--- a/index.html
+++ b/index.html
@@ -90,6 +90,13 @@
           <li class="menu-item">
             <div class="menu-item-name">BIRRIA TACO's<span class="menu-item-price">149:-</span></div>
             <div class="menu-item-description">Långkokt högrev, mozzarella, lök, persilja, lime & consumé</div>
+            <div class="progress-bar-container">
+              <div class="menu-item-description">~<span id="amountLeft">100%</span> av grytan finns kvar!</div>
+              <div class="progress-bar">
+                  <div class="progress"></div>
+              </div>
+              <p class="message"></p>
+            </div>
           </li>
            <li class="menu-item">
       <div class="menu-item-name">O's Fried Chicken Burger<span class="menu-item-price">149:-</span></div>

--- a/styles.css
+++ b/styles.css
@@ -160,12 +160,7 @@ body {
 .button {
   padding-top: 1rem;
   text-align: center;
-
-
-
 }
-
-
 
 .button a{
   background-color: #2e2e2e;
@@ -200,5 +195,37 @@ body {
 
 .blue {
   color: blue;
+}
+
+.progress-bar-container {
+    text-align: center;
+    background-color: black;
+    border-radius: 8px;
+    padding-top: 1vh;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.progress-bar-container .progress-bar {
+    background-color: #fff;
+    border-radius: 25px;
+    height: 2vh;
+    margin: 1vh 0;
+    position: relative;
+    border: 3px solid white; /* White border added here */
+}
+
+.progress-bar-container .progress {
+    height: 100%;
+    width: 100%;
+/*  background-color: #6BBF4F; */
+/*  background-color: #F4C531; */
+/*  background-color: #D9534F; */
+    border-radius: 25px;
+}
+
+.progress-bar-container .message {
+    font-size: 18px;
+    font-weight: bold;
+    color: #d9534f;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -198,34 +198,84 @@ body {
 }
 
 .progress-bar-container {
-    text-align: center;
-    background-color: black;
-    border-radius: 8px;
-    padding-top: 1vh;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  background-color: black;
+  border-radius: 8px;
+  padding-top: 1vh;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .progress-bar-container .progress-bar {
-    background-color: #fff;
-    border-radius: 25px;
-    height: 2vh;
-    margin: 1vh 0;
-    position: relative;
-    border: 3px solid white; /* White border added here */
+  background-color: #fff;
+  border-radius: 25px;
+  height: 10px;
+  margin: 1vh 0;
+  position: relative;
+  border: 3px solid white; /* White border added here */
 }
 
 .progress-bar-container .progress {
-    height: 100%;
-    width: 100%;
-/*  background-color: #6BBF4F; */
-/*  background-color: #F4C531; */
-/*  background-color: #D9534F; */
-    border-radius: 25px;
+  height: 100%;
+  border-radius: 25px;
 }
 
-.progress-bar-container .message {
-    font-size: 18px;
-    font-weight: bold;
-    color: #d9534f;
+.progress-bar-container._100 .progress {
+  background-color: #6BBF4F;
+  width: 100%;
+}
+
+.progress-bar-container._75 .progress {
+  background-color: #6BBF4F;
+  width: 75%;
+}
+
+.progress-bar-container._50 .progress {
+  background-color: #F4C531;
+  width: 50%;
+}
+
+.progress-bar-container._25 .progress {
+  background-color: #D9534F;
+  width: 25%;
+}
+
+.progress-bar-container._0 .progress {
+  background-color: #D9534F;
+  width: 0%;
+}
+
+.progress-bar-container._100 .menu-item-description #amountLeft:before {
+  content: "100";
+}
+
+.progress-bar-container._75 .menu-item-description #amountLeft:before {
+  content: "75";
+}
+
+.progress-bar-container._50 .menu-item-description #amountLeft:before {
+  content: "50";
+}
+
+.progress-bar-container._25 .menu-item-description #amountLeft:before {
+  content: "25";
+}
+
+.progress-bar-container._0 .menu-item-description {
+  display: none;
+}
+
+.progress-bar-container._0 .progress-bar {
+  display: none;
+}
+
+.progress-bar-container .empty-message {
+  display: none;
+  font-size: 2vw;
+  font-weight: bold;
+  color: #d9534f;
+}
+
+.progress-bar-container._0 .empty-message {
+  display: inline;
 }
 


### PR DESCRIPTION
Added progress meter for remaining Birria. Will require manual update of html to change estimated remaining amount.

Supported levels are 100%, 75%, 50%, 25% and 0% and can be set by changing the class of `progress-bar-container` to `_100`, `_75`, `_50` etc. Changing the class will ensure that metre progress, color and description is updated appropriately.